### PR TITLE
Fix: Removed usage of global, fixed load order.

### DIFF
--- a/Contents/mods/ProximityInventory/media/lua/client/ProximityInventory.client.lua
+++ b/Contents/mods/ProximityInventory/media/lua/client/ProximityInventory.client.lua
@@ -1,11 +1,13 @@
-require "ISUI/ISPanel"
-require "ISUI/ISButton"
-require "ISUI/ISInventoryPane"
-require "ISUI/ISResizeWidget"
-require "ISUI/ISMouseDrag"
-require "ISUI/ISLayoutManager"
-require "Definitions/ContainerButtonIcons"
-require "defines"
+-- require "ISUI/ISPanel"
+-- require "ISUI/ISButton"
+-- require "ISUI/ISInventoryPane"
+-- require "ISUI/ISResizeWidget"
+-- require "ISUI/ISMouseDrag"
+-- require "ISUI/ISLayoutManager"
+-- require "Definitions/ContainerButtonIcons"
+-- require "defines"
+
+local ProxInv = require("ProximityInventory.core")
 
 function ISInventoryPage.GetLocalContainer(playerNum)
 	if ISInventoryPage.localContainer == nil then

--- a/Contents/mods/ProximityInventory/media/lua/client/ProximityInventory.core.lua
+++ b/Contents/mods/ProximityInventory/media/lua/client/ProximityInventory.core.lua
@@ -1,4 +1,5 @@
-ProxInv = {}
+local ProxInv = {}
+
 ProxInv.isToggled = true
 ProxInv.isHighlightToggled = false
 ProxInv.isForceSelected = false
@@ -71,3 +72,5 @@ ProxInv.populateContextMenuOptions = function (context)
 	local optHightlight = context:addOption(highlightToggleText.." Hightlight", nil, ProxInv.setHighlightToggled)
 	optHightlight.iconTexture = ProxInv.inventoryIcon;
 end
+
+return ProxInv

--- a/Contents/mods/ProximityInventoryZombonly/media/lua/client/ProximityInventoryZombonly.client.lua
+++ b/Contents/mods/ProximityInventoryZombonly/media/lua/client/ProximityInventoryZombonly.client.lua
@@ -1,11 +1,13 @@
-require "ISUI/ISPanel"
-require "ISUI/ISButton"
-require "ISUI/ISInventoryPane"
-require "ISUI/ISResizeWidget"
-require "ISUI/ISMouseDrag"
-require "ISUI/ISLayoutManager"
-require "Definitions/ContainerButtonIcons"
-require "defines"
+-- require "ISUI/ISPanel"
+-- require "ISUI/ISButton"
+-- require "ISUI/ISInventoryPane"
+-- require "ISUI/ISResizeWidget"
+-- require "ISUI/ISMouseDrag"
+-- require "ISUI/ISLayoutManager"
+-- require "Definitions/ContainerButtonIcons"
+-- require "defines"
+
+local ProxInv = require("ProximityInventory.core")
 
 ProxInv.zombieTypes = {
 	inventoryfemale = true,


### PR DESCRIPTION
Using `require` and returning local modules will save you a lot of headache when you want to control the load order of your mods. Also requiring vanilla game files is useless, they are all loaded before mods. :)