### PR TITLE
Make ProximityInventory object local. Basic optimization of for loops

### DIFF
--- a/Contents/mods/ProximityInventory/common/media/lua/client/ProximityInventory/ISInventoryPage.lua
+++ b/Contents/mods/ProximityInventory/common/media/lua/client/ProximityInventory/ISInventoryPage.lua
@@ -1,3 +1,5 @@
+local ProximityInventory = require("ProximityInventory/ProximityInventory")
+
 local old_ISInventoryPage_update = ISInventoryPage.update
 function ISInventoryPage:update()
   old_ISInventoryPage_update(self)
@@ -8,26 +10,25 @@ function ISInventoryPage:update()
   -- but just injecting the table is is SOO much simpler, so I'll just inject it here
   self.coloredProxInventories = self.coloredProxInventories or {}
 
-  for _, container in ipairs(self.coloredProxInventories) do
-    local parent = container:getParent()
+  for i=#self.coloredProxInventories, 1, -1 do
+    local parent = self.coloredProxInventories[i]:getParent()
     if parent then
       parent:setHighlighted(false)
       parent:setOutlineHighlight(false);
       parent:setOutlineHlAttached(false);
     end
+    self.coloredProxInventories[i]=nil
   end
-
-  table.wipe(self.coloredProxInventories)
 
   if not ProximityInventory.isHighlightEnableOption:getValue() or self.isCollapsed or self.inventory:getType() ~= "proxInv" then return end
 
-  for _, button in ipairs(self.backpacks) do
-    local container = button.inventory
+  for i=1, #self.backpacks do
+    local container = self.backpacks[i].inventory
     local parent = container:getParent()
     if parent and (instanceof(parent, "IsoObject") or instanceof(parent, "IsoDeadBody")) then
       parent:setHighlighted(true, false)
       parent:setHighlightColor(getCore():getObjectHighlitedColor())
-      table.insert(self.coloredProxInventories, container)
+      self.coloredProxInventories[#self.coloredProxInventories+1] = container
     end
   end
 end

--- a/Contents/mods/ProximityInventory/common/media/lua/client/ProximityInventory/ProximityInventory.lua
+++ b/Contents/mods/ProximityInventory/common/media/lua/client/ProximityInventory/ProximityInventory.lua
@@ -1,4 +1,4 @@
-ProximityInventory = ProximityInventory or {}
+local ProximityInventory = {}
 
 -- Options
 ProximityInventory.options = PZAPI.ModOptions:create("ProximityInventory", "Proximity Inventory")
@@ -176,3 +176,5 @@ Events.OnRefreshInventoryWindowContainers.Add(function(invSelf, state)
     return ProximityInventory.OnButtonsAdded(invSelf)
   end
 end)
+
+return ProximityInventory


### PR DESCRIPTION
Heya! Did a quick review, and everything looks good!  Tried it out in-game, and everything seems to work too.

I did make some small adjustments though.

1. I removed the "ProximityInventory" table that you created out of the global space. It's typically bad practice to do so.   Instead, the "ProximityInventory/ISInventoryPage.lua" now calls "require" on that to pull it in, and stores it as a local variable. This helps with performance as well.
2. I refactored all for loops to use the indexes directly and not rely on the `ipairs` function, which is notoriously slow. 

One other suggestion would be to place the code in the "42" folder instead of "common".  I'm not fully sure if this will be compatible with future versions as there are already signs of inventory/UI refactoring in B42, and I think it's recommended to only be putting art and other items like that in the "common" folder instead of code. 

Otherwise, great work!